### PR TITLE
Standard library linking fixes.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
   dune
   (ocaml
    (>= "4.13"))
+  ocamlfind
   GT
   (OCanren
    (>= "0.3.0~"))

--- a/noCanren.opam
+++ b/noCanren.opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/Lozov-Petr/noCanren/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.13"}
+  "ocamlfind"
   "GT"
   "OCanren" {>= "0.3.0~"}
   "OCanren-ppx" {>= "0.3.0~"}

--- a/src/noCanren.ml
+++ b/src/noCanren.ml
@@ -17,7 +17,10 @@ let get_translator tast params =
 ;;
 
 let translate ppf params =
-  Clflags.include_dirs := List.append std_lib_pathes !Clflags.include_dirs;
+  Clflags.include_dirs
+    := if params.need_std
+       then List.append (get_std_lib_pathes ()) !Clflags.include_dirs
+       else !Clflags.include_dirs;
   Clflags.include_dirs := List.append params.include_dirs !Clflags.include_dirs;
   Clflags.open_modules := List.append params.opens !Clflags.open_modules;
   Compmisc.init_path ();
@@ -91,6 +94,7 @@ let useGT = ref false
 let gen_info = ref Util.Only_distribs
 let reexport_path = ref None
 let syntax_extenstions = ref true
+let need_std = ref true
 
 module OcamlcOptions = Main_args.Make_bytecomp_options (Main_args.Default.Main)
 
@@ -175,6 +179,8 @@ let all_options =
         (fun s ->
           reexport_path := if s = "" then Some [] else Some (String.split_on_char '.' s))
     , " Add a module path for reexporting of types" )
+  ; "-std", Arg.Unit (fun _ -> need_std := true), "Use std libraries (default)"
+  ; "-no-std", Arg.Unit (fun _ -> need_std := false), "Do not use std libraries."
   ]
   @ OcamlcOptions.list
 ;;
@@ -224,6 +230,7 @@ let mk_noCanren_params () =
   ; syntax_extenstions = !syntax_extenstions
   ; output_name_for_spec_tree = !output_name_for_spec_tree
   ; reexport_path = !reexport_path
+  ; need_std = !need_std
   }
 ;;
 

--- a/src/util.ml
+++ b/src/util.ml
@@ -61,6 +61,7 @@ type noCanren_params =
   ; syntax_extenstions : bool
   ; output_name_for_spec_tree : string option
   ; reexport_path : string list option
+  ; need_std : bool
   }
 
 type binding =
@@ -92,7 +93,20 @@ let synonoms_module_name = "FO"
 let ctor_module_prefix = "For_"
 let packages = [ "GT"; "OCanren" ]
 let std_lib_names = [ "noCanren.List"; "noCanren.Maybe"; "noCanren.Peano" ]
-let std_lib_pathes = List.map Findlib.package_directory std_lib_names
+
+let get_std_lib_pathes () =
+  List.filter_map
+    (fun name ->
+      let open Findlib in
+      try Some (package_directory name) with
+      | No_such_package (lib_name, reason) ->
+        Printf.eprintf
+          "No such std package '%s'%s\n"
+          lib_name
+          (if reason <> "" then Printf.sprintf ", reason: %s" reason else ".");
+        None)
+    std_lib_names
+;;
 
 (***************************** Fail util **********************************)
 

--- a/std/dune
+++ b/std/dune
@@ -33,7 +33,7 @@
   (run
    sh
    -c
-   "%{exec} -w -8 -rectypes -I `ocamlfind -query OCanren` %{input} -o %{targets}")))
+   "%{exec} -w -8 -rectypes -no-std -I `ocamlfind -query OCanren` %{input} -o %{targets}")))
 
 (library
  (name List)
@@ -53,4 +53,4 @@
   (run
    sh
    -c
-   "%{exec} -w -8 -rectypes -I `ocamlfind -query OCanren` %{input} -o %{targets}")))
+   "%{exec} -w -8 -rectypes -no-std -I `ocamlfind -query OCanren` -I .Peano.objs/byte %{input} -o %{targets}")))


### PR DESCRIPTION
Added error handling when searching for the path to the standard library. Added the feature to disable automatic linking of the standard library (-no-std). Added 'ocamlfind' to dependencies. 